### PR TITLE
feat: versioning to the current/latest stable version of dotnet 9

### DIFF
--- a/ApiGenerator.DotNet.csproj
+++ b/ApiGenerator.DotNet.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>


### PR DESCRIPTION
@andrescollazosc It's because I don't have version 7 installed, so my laptop can't run this and won't be supported in the near future.